### PR TITLE
fix: remove await within async useAsyncData composables

### DIFF
--- a/components/content/Toc.vue
+++ b/components/content/Toc.vue
@@ -50,8 +50,8 @@ const config = useAppConfig()
 const showTocChildren = props.showChildren || (config.toc?.showChildren ?? false)
 
 const route = useRoute()
-const { data: doc } = await useAsyncData(route.path, async () => {
-    return await queryContent('').where({ _path: route.path }).findOne()
+const { data: doc } = await useAsyncData(route.path, () => {
+    return queryContent('').where({ _path: route.path }).findOne()
 })
 
 const isTocEnabled = doc.value?.body?.toc?.links.length && doc.value?.body.toc?.links.length > 0

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -51,7 +51,7 @@ if (isCategory) {
     })
     page = Number.parseInt(slug[3]) || 1
     const where = { categories: { $in: category }, hidden: { $ne: true }, listed: { $ne: false } }
-    const {data: result, error} = await useAsyncData(route.path, async () => {
+    const {data: result, error} = await useAsyncData(route.path, () => {
         let queryBuilder = queryContent('')
             .where(where)
             .sort({ date: -1 })
@@ -60,7 +60,7 @@ if (isCategory) {
             queryBuilder = queryBuilder.limit(numberOfPostsPerPage).skip((page - 1) * numberOfPostsPerPage)
         }
 
-        return await queryBuilder.find()
+        return queryBuilder.find()
     })
 
     // Check for fetch error
@@ -84,7 +84,7 @@ if (isCategory) {
     page = Number.parseInt(slug[2]) || 1
     const where = { hidden: { $ne: true }, listed: { $ne: false }}
 
-    const {data: result, error } = await useAsyncData(route.path, async () => {
+    const {data: result, error } = await useAsyncData(route.path, () => {
         let queryBuilder = queryContent('')
             .where(where)
             .sort({ date: -1 })
@@ -93,7 +93,7 @@ if (isCategory) {
             queryBuilder = queryBuilder.limit(numberOfPostsPerPage).skip((page - 1) * numberOfPostsPerPage)
         }
 
-        return await queryBuilder.find()
+        return queryBuilder.find()
     })
 
     // Check for fetch error
@@ -119,7 +119,7 @@ if (isCategory) {
     })
     page = Number.parseInt(slug[2]) || 1
     const where = { tags: { $in: tag }, hidden: { $ne: true }, listed: { $ne: false } }
-    const {data: result, error} = await useAsyncData(route.path, async () => {
+    const {data: result, error} = await useAsyncData(route.path, () => {
         let queryBuilder = queryContent('')
             .where(where)
             .sort({ date: -1 })
@@ -128,7 +128,7 @@ if (isCategory) {
             queryBuilder = queryBuilder.limit(numberOfPostsPerPage).skip((page - 1) * numberOfPostsPerPage)
         }
 
-        return await queryBuilder.find()
+        return queryBuilder.find()
     })
 
     // Check for fetch error
@@ -140,8 +140,8 @@ if (isCategory) {
     docs = result
     theme = `themes-${config.theme}-tag`
 } else {
-    const {data: result, error} = await useAsyncData(route.path, async () => {
-        return await queryContent('').where({ _path: route.path }).findOne()
+    const {data: result, error} = await useAsyncData(route.path, () => {
+        return queryContent('').where({ _path: route.path }).findOne()
     })
 
     // Check for fetch error


### PR DESCRIPTION
Using await within an async useAsyncData() is not recommended see [Nuxt documentation](https://nuxt.com/docs/api/composables/use-async-data#:~:text=If%20you%27re%20using%20a%20custom%20useAsyncData%20wrapper%2C%20do%20not%20await%20it%20in%20the%20composable%2C%20as%20that%20can%20cause%20unexpected%20behavior.%20Please%20follow%20this%20recipe%20for%20more%20information%20on%20how%20to%20make%20a%20custom%20async%20data%20fetcher.).

Removes await from async useAsyncData() uses.
Removes async when not needed. 