### PR TITLE
fix: rss image URL missing leading slash

### DIFF
--- a/server/routes/rss.xml.ts
+++ b/server/routes/rss.xml.ts
@@ -1,5 +1,6 @@
 import { serverQueryContent } from '#content/server'
 import { Feed } from 'feed'
+import { withLeadingSlash } from 'ufo'
 
 export default defineEventHandler(async (event) => {
     const config = useAppConfig()
@@ -31,7 +32,7 @@ export default defineEventHandler(async (event) => {
                 link: url + path,
                 description: post.description,
                 date: new Date(post.date),
-                image: post.cover ? url + post.cover : undefined,
+                image: post.cover ? url + withLeadingSlash(post.cover) : undefined,
             })
         }
     })


### PR DESCRIPTION
## Linked Issue

Fix #20 

## Description

Updates logic in [`server/routes/rss.xml.ts`](https://github.com/bloggrify/bloggrify/blob/7b29fa33a125742cec851ec26fab07bcb1c9f78a/server/routes/rss.xml.ts#L34) to ensure a leading slash is present.

Feedback and suggestions are welcome!