### PR TITLE
Upgrade links to HTTPS in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### ❤️ Contributors
 
 - Hugo Lassiège <hlassiege@gmail.com>
-- IO-Fire ([@IO-Fire](http://github.com/IO-Fire))
+- IO-Fire ([@IO-Fire](https://github.com/IO-Fire))
 
 ## v1.7.0
 
@@ -51,7 +51,7 @@
 ### ❤️ Contributors
 
 - Hugo Lassiège <hlassiege@gmail.com>
-- IO-Fire ([@IO-Fire](http://github.com/IO-Fire))
+- IO-Fire ([@IO-Fire](https://github.com/IO-Fire))
 
 ## v1.6.0
 
@@ -74,7 +74,7 @@
 ### ❤️ Contributors
 
 - Hugo Lassiège <hlassiege@gmail.com>
-- IO-Fire ([@IO-Fire](http://github.com/IO-Fire))
+- IO-Fire ([@IO-Fire](https://github.com/IO-Fire))
 
 ## v1.5.0
 


### PR DESCRIPTION
Updates contributors profile link protocols from HTTP to HTTPS.