### PR TITLE
feat: invalid layout

### DIFF
--- a/layouts/invalid.vue
+++ b/layouts/invalid.vue
@@ -1,0 +1,19 @@
+<!-- This layout exists to throw an error if the intended layout does not exist -->
+<!-- Example <NuxtLayout :name="my-missing-layout" fallback='invalid' /> -->
+
+<template>
+    <div>
+        <slot />
+    </div>
+</template>
+
+<script lang="ts" setup>
+
+// Throw an error instead of showing the layout
+throw createError({
+    name: 'Invalid layout',
+    fatal: false,
+    statusMessage: 'Invalid layout'
+})
+</script>
+

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,5 +1,5 @@
 <template>
-    <NuxtLayout :name="theme" :doc="doc" :docs="docs" :current-page="page" :total="totalNumberOfPages" :category="category" :tag="tag" />
+    <NuxtLayout :name="theme" :doc="doc" :docs="docs" :current-page="page" :total="totalNumberOfPages" :category="category" :tag="tag" fallback='invalid' />
 </template>
 <script setup lang="ts">
 import type { NuxtError } from '#app'


### PR DESCRIPTION
## Linked Issue

Fix #28

## Description

Adds a new layout `invalid.vue` which throws an error.

Forces an error to be thrown in `pages/[slug].vue` when an invalid layout is specified. Sets the fallback layout to the new `invalid` layout.

Feedback and suggestions are welcome!