### PR TITLE
fix!: SSG path miss-match

### DIFF
--- a/components/content/Toc.vue
+++ b/components/content/Toc.vue
@@ -38,6 +38,8 @@
     </div>
 </template>
 <script setup lang="ts">
+import { withoutTrailingSlash } from 'ufo'
+
 const props = defineProps({
     showChildren: {
         type: Boolean,
@@ -51,7 +53,7 @@ const showTocChildren = props.showChildren || (config.toc?.showChildren ?? false
 
 const route = useRoute()
 const { data: doc } = await useAsyncData(route.path, () => {
-    return queryContent('').where({ _path: route.path }).findOne()
+    return queryContent('').where({ _path: withoutTrailingSlash(route.path) }).findOne()
 })
 
 const isTocEnabled = doc.value?.body?.toc?.links.length && doc.value?.body.toc?.links.length > 0

--- a/content/markdown.md
+++ b/content/markdown.md
@@ -233,6 +233,6 @@ https://twitter.com/hugolassiege/status/1750435525071159309
 
 ::alert{type="tip"}
 On top of the standard markdown features, you can also use custom components with Vue.js to extend markdown features.  
-Read the [custom components documentation](/custom-components) to learn more.
+Read the [custom components documentation](/custom-components/) to learn more.
 
 ::

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,6 +24,22 @@ export default defineNuxtConfig({
         format: ['webp'],
     },
 
+    experimental: {
+        defaults: {
+            nuxtLink: {
+                trailingSlash: 'append'
+            }
+        }
+    },
+
+    hooks: {
+        'pages:extend'(pages) {
+            for (const page of pages) {
+                page.path = page.path.endsWith('/') ? page.path : page.path + '/'
+            }
+        },
+    },
+
     content: {
         markdown: {
             remarkPlugins: ['remark-reading-time', 'remark-math', 'remark-mermaidjs'],

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -3,6 +3,7 @@
 </template>
 <script setup lang="ts">
 import type { NuxtError } from '#app'
+import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
 const route = useRoute()
 const config = useAppConfig()
@@ -141,7 +142,7 @@ if (isCategory) {
     theme = `themes-${config.theme}-tag`
 } else {
     const {data: result, error} = await useAsyncData(route.path, () => {
-        return queryContent('').where({ _path: route.path }).findOne()
+        return queryContent('').where({ _path: withoutTrailingSlash(route.path) }).findOne()
     })
 
     // Check for fetch error
@@ -186,7 +187,7 @@ if (isCategory) {
     }
 
     const url = useAppConfig().url.replace(/\/$/, '')
-    const postLink = url + doc.value?._path
+    const postLink = withTrailingSlash(url + doc.value?._path)
 
     useSeoMeta({
         ogType: 'article',

--- a/server/routes/rss.xml.ts
+++ b/server/routes/rss.xml.ts
@@ -1,6 +1,6 @@
 import { serverQueryContent } from '#content/server'
 import { Feed } from 'feed'
-import { withLeadingSlash } from 'ufo'
+import { withLeadingSlash, withTrailingSlash } from 'ufo'
 
 export default defineEventHandler(async (event) => {
     const config = useAppConfig()
@@ -25,11 +25,12 @@ export default defineEventHandler(async (event) => {
     })
     docs.forEach((post) => {
         const path = post._path
+        const postURL = withTrailingSlash(url + path)
         if (post.date) {
             feed.addItem({
                 title: post.title ?? '-',
-                id: url + path,
-                link: url + path,
+                id: postURL,
+                link: postURL,
                 description: post.description,
                 date: new Date(post.date),
                 image: post.cover ? url + withLeadingSlash(post.cover) : undefined,

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
     })
     for (const doc of docs) {
         sitemap.write({
-            url: cleanDoubleSlashes(url + withoutLeadingSlash(doc._path)),
+            url: withTrailingSlash(cleanDoubleSlashes(url + withoutLeadingSlash(doc._path))),
             lastmod: doc.date ,
             img: doc.cover ? [{
                 url: url + withoutLeadingSlash(doc.cover),


### PR DESCRIPTION
## Linked Issue

Fix #30

## Description

> [!CAUTION]
>  BREAKING CHANGE: Requires paths to have a trailing slash

Updates page path logic to include a trailing slash unless a `contentQuery()` composable is used.

Feedback and suggestions are welcome!